### PR TITLE
fix #2: fix :ReactAndroid project dependency

### DIFF
--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 }
 
 dependencies {
-    compile project(':ReactAndroid')
+    compile "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
Replace `compile project(':ReactAndroid')` with `compile
"com.facebook.react:react-native:+"` as suggested in
https://github.com/tkporter/react-native-sms/issues/2

fixes #2