### PR TITLE
Prevent app stale when canSendText is negative

### DIFF
--- a/SendSMS/SendSMS.m
+++ b/SendSMS/SendSMS.m
@@ -38,6 +38,9 @@ RCT_EXPORT_METHOD(send:(NSDictionary *)options :(RCTResponseSenderBlock)callback
         messageController.messageComposeDelegate = self;
         UIViewController *rootView = [UIApplication sharedApplication].keyWindow.rootViewController;
         [rootView presentViewController:messageController animated:YES completion:nil];
+    } else {
+        bool completed = NO, cancelled = NO, error = YES;
+        _callback(@[@(completed), @(cancelled), @(error)]);
     }
 }
 


### PR DESCRIPTION
Handle scenario where canSendText is false.

If not handled correctly causes an stale react-native app, now also is compatible for testing at the simulator.

@tkporter Thanks for this great lib