### PR TITLE
Update SendSMSModule.java

### DIFF
--- a/android/src/main/java/com/tkporter/sendsms/SendSMSModule.java
+++ b/android/src/main/java/com/tkporter/sendsms/SendSMSModule.java
@@ -88,7 +88,9 @@ public class SendSMSModule extends ReactContextBaseJavaModule implements Activit
                 String recipientString = "";
                 for (int i = 0; i < recipients.size(); i++) {
                     recipientString += recipients.getString(i);
-                    recipientString += separator;
+                    if(i + 1 < recipients.size()) { 
+                        recipientString += separator;
+                    }
                 }
                 sendIntent.putExtra("address", recipientString);
             }


### PR DESCRIPTION
When sending, recipient list always ends with a comma, which makes the messages app say the wrong # of recipients (+1). There shouldn't be a delimiter at the end of the recipient string.