### PR TITLE
React 47 no longer has createJSModules override

### DIFF
--- a/android/src/main/java/com/tkporter/sendsms/SendSMSPackage.java
+++ b/android/src/main/java/com/tkporter/sendsms/SendSMSPackage.java
@@ -28,7 +28,6 @@ public class SendSMSPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(sendSms);
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
`createJSModules` [was removed in React Native 0.47.0](https://github.com/facebook/react-native/releases/tag/v0.47.0) and results in the attached Build Error.
Removing `@Override` fixes build.  Should bump major release when this is merged, so 46.0 and below still have override.