### PR TITLE
fix: race condition when sending many consecutive SMS's

### DIFF
--- a/SendSMS/SendSMS.m
+++ b/SendSMS/SendSMS.m
@@ -60,10 +60,9 @@ RCT_EXPORT_METHOD(send:(NSDictionary *)options :(RCTResponseSenderBlock)callback
             error = YES;
             break;
     }
-    
-    _callback(@[@(completed), @(cancelled), @(error)]);
-
-    [controller dismissViewControllerAnimated:YES completion:nil];
+    [controller dismissViewControllerAnimated:YES completion:^{
+        _callback(@[@(completed), @(cancelled), @(error)]);
+    }];
 }
 
 @end


### PR DESCRIPTION
There was a race condition when sending multiple consecutive SMS's on iOS, this commit waits for the modal to dismiss before calling back to javascript solving the issue