### PR TITLE
add flag for allowing opening sms intent without requesting permissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@
 
 import { NativeModules, PermissionsAndroid, Platform } from 'react-native'
 
-async function send(options: Object, callback: () => void) {
-  if (Platform.OS === 'android') {
+async function send(options: Object, callback: () => void, requestPermission: boolean = true) {
+  if (Platform.OS === 'android' && requestPermission) {
     try {
       let authorized = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_SMS)
     } catch (error) {


### PR DESCRIPTION
Opening the sms intent actually does not require that the app have sms permissions. However, this will not break previous usages of the app due to default param.