### PR TITLE
add super call so it doesn't break other libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Inside MainActivity (place entire function if it's not there already)
 ```Java
 @Override
 public void onActivityResult(int requestCode, int resultCode, Intent data) {
+	super.onActivityResult(requestCode, resultCode, data);
 	//probably some other stuff here
 	SendSMSPackage.getInstance().onActivityResult(requestCode, resultCode, data);
 }


### PR DESCRIPTION
On Android `super.onActivityResult(requestCode, resultCode, data)` is required so it doesn't break React Context's `ActivityEventListener`. With no super call other libs might be broken by mistake (happened to me with react-native-google-signin).

Adding it to the readme might avoid some confusions being created with other libs.