### PR TITLE
Remove extra whitespace at the end of recipients string

### DIFF
--- a/android/src/main/java/com/tkporter/sendsms/SendSMSModule.java
+++ b/android/src/main/java/com/tkporter/sendsms/SendSMSModule.java
@@ -90,6 +90,7 @@ public class SendSMSModule extends ReactContextBaseJavaModule implements Activit
                     recipientString += recipients.getString(i);
                     recipientString += separator;
                 }
+                recipientString = recipientString.substring(0, recipientString.length() - 1);
                 sendIntent.putExtra("address", recipientString);
             }
 

--- a/android/src/main/java/com/tkporter/sendsms/SendSMSModule.java
+++ b/android/src/main/java/com/tkporter/sendsms/SendSMSModule.java
@@ -81,16 +81,15 @@ public class SendSMSModule extends ReactContextBaseJavaModule implements Activit
             //if recipients specified
             if (recipients != null) {
                 //Samsung for some reason uses commas and not semicolons as a delimiter
-                String separator = "; ";
+                String separator = ";";
                 if(android.os.Build.MANUFACTURER.equalsIgnoreCase("Samsung")){
-                    separator = ", ";
+                    separator = ",";
                 }
                 String recipientString = "";
                 for (int i = 0; i < recipients.size(); i++) {
                     recipientString += recipients.getString(i);
                     recipientString += separator;
                 }
-                recipientString = recipientString.substring(0, recipientString.length() - 1);
                 sendIntent.putExtra("address", recipientString);
             }
 


### PR DESCRIPTION
Hi @tkporter 

As discussed in [here](https://github.com/tkporter/react-native-sms/issues/41) I worked on the issue of the "whitespace contact" automatically added on my phone.
I manage to fix it by removing the last character of the recipientString which is always a whitespace.

![whatsapp image 2017-12-22 at 13 51 20](https://user-images.githubusercontent.com/15011364/34298798-cc7dc3c0-e71f-11e7-85a6-c4def9bc08d3.jpeg)

I'm not familiar with Java (I'm only coding in RN), don't hesitate to make some comments :)

