### PR TITLE
Send SMS in Android without opening a messaging app

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,19 @@
 ## SendSMS
 Use this RN component to send an SMS with a callback (completed/cancelled/error). iOS and Android are both supported.
 
-Currently, only user-initiated sending of an SMS is supported. This means you can't use `react-native-sms` to send an SMS in the background-- this package displays the native SMS view (populated with any recipients/body you want), and gives a callback describing the status of the SMS (completed/cancelled/error). PRs are welcome!
+Currently, only user-initiated sending of an SMS is supported. 
+This means you can't use `react-native-sms` to send an SMS in the background -- this package displays the native SMS view (populated with any recipients/body you want), and gives a callback describing the status of the SMS (completed/cancelled/error). PRs are welcome!
+### Update
+A new prop was added to enable direct sending of SMS from Android. see documentation below.
 
 ## How to install
 1. `npm install react-native-sms --save`
 
 ## Getting things set up
 
-The compiler needs to know how to find your sweet new module! (Make sure rnpm is installed via `npm install rnpm -g`)
+The compiler needs to know how to find your sweet new module!
 
-`rnpm link react-native-sms`
+`react-native link react-native-sms`
 
 ### Additional Android Setup
 
@@ -29,7 +32,7 @@ import android.content.Intent; // <-- include if not already there
 import com.tkporter.sendsms.SendSMSPackage;
 ```
 
-Inside MainActivity (place entire function if it's not there already)
+Inside **`MainActivity`** (place entire function if it's not there already)
 ```Java
 @Override
 public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -39,7 +42,7 @@ public void onActivityResult(int requestCode, int resultCode, Intent data) {
 }
 ```
 
-Then head to your [MyApp]Application.java (`MyApp/android/app/src/main/java/so/many/dirs/MyAppApplication.java`)
+Then head to your **`[MyApp]Application.java`** (`MyApp/android/app/src/main/java/so/many/dirs/MyAppApplication.java`)
 
 Make sure `import com.tkporter.sendsms.SendSMSPackage;` is there
 
@@ -56,15 +59,16 @@ protected List<ReactPackage> getPackages() {
 }
 ```
 
-Navigate to your `AndroidManifest.xml` (at `MyApp/android/app/src/main/AndroidManifest.xml`), and add this near the top with the other permssions
+FYI: this permission will automatically be merged into your built `AndroidManifest.xml` (at `MyApp/android/app/src/main/AndroidManifest.xml`)
 ```XML
 <uses-permission android:name="android.permission.READ_SMS" />
 ```
 
-Ensure your launchMode for `.MainActivity` is
+If `direct_send` is `false` or undefined - then ensure your launchMode for `MainActivity` is
 ```XML
 android:launchMode="singleTask"
 ```
+in order for the "back" button to return to your app after the message window is closed.
 
 ## Using the module
 
@@ -84,6 +88,11 @@ The text that shows by default when the SMS is initiated
 Provides the phone number recipients to show by default
 
 `successTypes` (Array (strings), Andriod only, required)
+
+`direct_send` (boolean, optional)
+
+If true, the Android app will send the SMS directly (without a native messaging app).
+It will loop on the recepients and send one by one.
 
 An array of types that would trigger a "completed" response when using android
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,22 +1,23 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.tkporter.sendsms">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.tkporter.sendsms">
+
+    <uses-permission android:name="android.permission.SEND_SMS" />
 </manifest>


### PR DESCRIPTION
I've added a new prop to enable sending sms in Android without opening a messaging app.
The change is backward compatible (when not setting the prop to `true`, there is not change from current flow).
