### PR TITLE
Only call onActivityResult when SendSMSModule is not null

### DIFF
--- a/android/src/main/java/com/tkporter/sendsms/SendSMSPackage.java
+++ b/android/src/main/java/com/tkporter/sendsms/SendSMSPackage.java
@@ -46,6 +46,8 @@ public class SendSMSPackage implements ReactPackage {
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        sendSms.onActivityResult(null, requestCode, resultCode, data);
+        if (sendSms != null) {
+            sendSms.onActivityResult(null, requestCode, resultCode, data);
+        }
     }
 }


### PR DESCRIPTION
At @root-app, we've seen an uptick of this error:

> Attempt to invoke virtual method 'void com.tkporter.sendsms.SendSMSModule.onActivityResult(android.app.Activity, int, int, android.content.Intent)' on a null object reference

There is [a comment on an Issue](https://github.com/tkporter/react-native-sms/issues/46#issuecomment-408851766) that is related, so this PR implements that suggestion.