### PR TITLE
Don't send SMS to users who deny view permissions on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,18 +3,30 @@
 
 import { NativeModules, PermissionsAndroid, Platform } from 'react-native'
 
-async function send(options: Object, callback: () => void) {
-  if (Platform.OS === 'android') {
-    try {
-      let authorized = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_SMS)
-    } catch (error) {
-
-    }
+async function checkForAndroidAuthorized() {
+  if (Platform.OS !== 'android') {
+    return false;
   }
-  NativeModules.SendSMS.send(options, callback);
+
+  let authorized;
+
+  try {
+    authorized = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_SMS);
+  } catch (error) {
+    // do nothing
+  }
+
+  return authorized === PermissionsAndroid.RESULTS.GRANTED;
 }
 
-let SendSMS = {
+async function send(options: Object, callback: () => void) {
+  const isAndroidAuthorized = await checkForAndroidAuthorized();
+  if (Platform.OS !== 'android' || isAndroidAuthorized) {
+    NativeModules.SendSMS.send(options, callback);
+  }
+}
+
+const SendSMS = {
   send
 }
 


### PR DESCRIPTION
We've seen this error using a fork of this repo @root-app:

> Permission Denial: reading com.android.providers.telephony.SmsProvider uri content://sms/ from pid=28072, uid=10247 requires android.permission.READ_SMS, or grantUriPermission()
com.tkporter.sendsms.SendSMSObserver.onChange

The issue was that the `.send()` function was not waiting for confirmation of the user's permissions before proceeding to send, so it would open the messaging app, allow the user to send, and then throw the above error when executing the callback.

This PR waits for permission confirmation before sending.