### PR TITLE
Make android READ_SMS permission optional for sending but required for callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,23 +74,12 @@ SendSMS.send(myOptionsObject, callback);
 ```
 
 ### Object Properties
-
-`body` (String, optional)
-
-The text that shows by default when the SMS is initiated
-
-`recipients` (Array (strings), optional)
-
-Provides the phone number recipients to show by default
-
-`successTypes` (Array (strings), Andriod only, required)
-
-An array of types that would trigger a "completed" response when using android
-
-Possible values:
-```JavaScript
-'all' | 'inbox' | 'sent' | 'draft' | 'outbox' | 'failed' | 'queued'
-```
+|Key|Type|Platforms|Required?|Description|
+|-|-|-|-|-|
+| `body` | String | iOS/Android | No | The text that shows by default when the SMS is initiated |
+| `recipients` | Array (strings) | iOS/Android | No | Provides the phone number recipients to show by default |
+| `successTypes` | Array (strings) | Android | Yes | An array of types that would trigger a "completed" response when using android <br/><br/> Possible values: <br/><br/> `'all' 'inbox' 'sent' 'draft' 'outbox' 'failed' 'queued'` |
+| `allowAndroidSendWithoutReadPermission` | boolean | Android | No | By default, SMS will only be initiated on Android if the user accepts the `READ_SMS` permission (which is required to provide completion statuses to the callback). <br/><br/> Passing `true` here will allow the user to send a message even if they decline the `READ_SMS` permission, and will then provide generic callback values (all false) to your application. |
 
 ## Example:
 
@@ -104,7 +93,8 @@ someFunction() {
 	SendSMS.send({
 		body: 'The default body of the SMS!',
 		recipients: ['0123456789', '9876543210'],
-		successTypes: ['sent', 'queued']
+		successTypes: ['sent', 'queued'],
+		allowAndroidSendWithoutReadPermission: true
 	}, (completed, cancelled, error) => {
 
 		console.log('SMS Callback: completed: ' + completed + ' cancelled: ' + cancelled + 'error: ' + error);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 import { NativeModules, PermissionsAndroid, Platform } from 'react-native'
 
-async function checkForAndroidAuthorized() {
+async function checkAndroidReadSmsAuthorized() {
   if (Platform.OS !== 'android') {
     return false;
   }
@@ -19,9 +19,16 @@ async function checkForAndroidAuthorized() {
   return authorized === PermissionsAndroid.RESULTS.GRANTED;
 }
 
+function isAuthorizedForCallback(androidCanReadSms) {
+  return Platform.OS !== 'android' || androidCanReadSms;
+}
+
 async function send(options: Object, callback: () => void) {
-  const isAndroidAuthorized = await checkForAndroidAuthorized();
-  if (Platform.OS !== 'android' || isAndroidAuthorized) {
+  const androidCanReadSms = await checkAndroidReadSmsAuthorized();
+
+  options.isAuthorizedForCallback = isAuthorizedForCallback(androidCanReadSms);
+
+  if (options.isAuthorizedForCallback || options.allowAndroidSendWithoutReadPermission) {
     NativeModules.SendSMS.send(options, callback);
   }
 }


### PR DESCRIPTION
This PR addresses feedback from https://github.com/tkporter/react-native-sms/pull/53#issuecomment-421422943, adding the ability to send SMS messages regardless of whether the Android user accepts the `READ_SMS` permission.

I've added a new optional boolean key (`allowAndroidSendWithoutReadPermission`) to the options object that calling applications will pass to `.send`.

If that key's value is true, we will open an SMS prompt regardless of whether the user accepts `READ_SMS` permissions, and then we early-return a generic callback with all false values before the `SendSMSObserver` attempts to use the read permission.

This should be helpful for implementations that don't care about the callback, and will also be relatively low-impact for implementations like the one we have at @root-app, where we do use the callback.