### PR TITLE
Pull android versions from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,13 +10,18 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', '23.0.1')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }
@@ -34,5 +39,5 @@ repositories {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
+    compile "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
 }


### PR DESCRIPTION
When using react-native 0.57, this project will not compile due to out of date android sdk build tools library.  This PR address this by following the recent RN convention of using the values from the root project.