### PR TITLE
Register content observer only when authorized for callback

### DIFF
--- a/android/src/main/java/com/tkporter/sendsms/SendSMSObserver.java
+++ b/android/src/main/java/com/tkporter/sendsms/SendSMSObserver.java
@@ -70,6 +70,10 @@ public class SendSMSObserver extends ContentObserver {
     }
 
     public void start() {
+        if (!this.isAuthorizedForCallback) {
+            return;
+        }
+
         if (resolver != null) {
             resolver.registerContentObserver(uri, true, this);
         }


### PR DESCRIPTION
This addresses https://github.com/tkporter/react-native-sms/issues/59

It appears that calling `registerContentObserver` on the context resolver when callback (SMS read) permissions are not enabled can cause crashing on some Android devices.

This PR only registers the content observer when authorized for callback (and that resolver is already only queried when authorized, so I believe this should be the only change needed).

I have tested this on a different device, but I don't have the affected device handy to confirm that this fixes the issue on that device, but perhaps @ObidosDev (who first reported the issue) can test it.