### PR TITLE
Fix rnpm warning (android)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,7 @@
   "name": "react-native-sms",
   "version": "1.10.1",
   "description": "A React Native library for Sending an SMS with Callback",
-  "main": "index",
-  "rnpm": {
-    "android": {
-      "packageInstance": "SendSMSPackage.getInstance()"
-    }
-  },
+  "main": "index.js",
   "scripts": {
     "test": "flow"
   },


### PR DESCRIPTION
Fix the following warning during Android build : 
```
warn The following packages use deprecated "rnpm" config that will stop working from next release:
  - react-native-sms: https://github.com/tkporter/react-native-sms
Please notify their maintainers about it. You can find more details at https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide.
```
It works without rnpm.

Tested on a `Samsung Galaxy Note 4` on `Android 6.0.1` with `react-native` `0.61.5`