### PR TITLE
fix: autolinking when using Xcode 12

### DIFF
--- a/react-native-sms.podspec
+++ b/react-native-sms.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
    s.platform       = :ios, "8.0"
    s.source         = { :git => "#{package_json["repository"]["url"]}" }
    s.source_files   = 'SendSMS/*.{h,m}'
-   s.dependency 'React'
+   s.dependency 'React-Core'
 
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly instead of `React`. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116