### PR TITLE
Replace JCenter with Maven Central as repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
See: https://jfrog.com/blog/jcenter-sunset/

Related issue: https://github.com/tkporter/react-native-sms/issues/105#issuecomment-1247794601